### PR TITLE
docs: rebrand to Heartwood public name

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,12 +1,25 @@
-# Project Instructions - GroveAuth
+# Project Instructions - Heartwood (GroveAuth)
 
 > **Note**: This is the main orchestrator file. For detailed guides, see `AgentUsage/README.md`
 
 ---
 
+## Naming
+
+| | |
+|---|---|
+| **Public Name** | Heartwood |
+| **Internal Codename** | GroveAuth |
+| **Domain** | heartwood.grove.place |
+| **Description** | The heartwood is the dense, authentic core of a tree — just as Heartwood is the secure authentication core of the Grove ecosystem. |
+
+> "All our sites use Heartwood for login"
+
+---
+
 ## Project Purpose
 
-GroveAuth is a centralized authentication service for all AutumnsGrove properties. It handles OAuth (Google, GitHub) and Magic Code (email) authentication, issuing JWT tokens that client sites can verify. Runs on Cloudflare Workers with D1 database.
+Heartwood (internally: GroveAuth) is a centralized authentication service for all AutumnsGrove properties. It handles OAuth (Google, GitHub) and Magic Code (email) authentication, issuing JWT tokens that client sites can verify. Runs on Cloudflare Workers with D1 database.
 
 ## Tech Stack
 

--- a/GROVEAUTH_SPEC.md
+++ b/GROVEAUTH_SPEC.md
@@ -1,9 +1,11 @@
-# GroveAuth - Centralized Authentication Service
+# Heartwood (GroveAuth) - Centralized Authentication Service
 
 > A Cloudflare Worker-based authentication service for all AutumnsGrove properties
 
-**Domain**: `auth.grove.place`
-**Project Name**: GroveAuth
+**Public Name**: Heartwood
+**Internal Codename**: GroveAuth
+**Public Domain**: `heartwood.grove.place`
+**API Domain**: `auth-api.grove.place` (internal backend)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
-# GroveAuth
+# Heartwood
 
 > Centralized authentication service for AutumnsGrove properties
 
-**Domain**: `auth.grove.place`
+**Public Name**: Heartwood
+**Internal Codename**: GroveAuth
+**Domain**: `heartwood.grove.place`
+
+*The heartwood is the dense, authentic core of a tree — just as Heartwood is the secure core of the Grove ecosystem.*
 
 ---
 
 ## Overview
 
-GroveAuth is a Cloudflare Worker-based authentication service that handles all authentication for AutumnsGrove sites. Instead of each site implementing its own auth logic, all sites redirect to GroveAuth for login and receive verified session tokens back.
+Heartwood is a Cloudflare Worker-based authentication service that handles all authentication for AutumnsGrove sites. Instead of each site implementing its own auth logic, all sites redirect to Heartwood for login and receive verified session tokens back.
 
 ### Features
 
@@ -45,7 +49,7 @@ GroveAuth is a Cloudflare Worker-based authentication service that handles all a
 ```bash
 # Clone the repository
 git clone https://github.com/AutumnsGrove/GroveAuth.git
-cd GroveAuth
+cd GroveAuth  # Internal codename used for repository
 
 # Install dependencies
 pnpm install
@@ -107,10 +111,10 @@ pnpm deploy
 
 ## Client Integration
 
-Sites authenticate with GroveAuth using the OAuth 2.0 Authorization Code flow:
+Sites authenticate with Heartwood using the OAuth 2.0 Authorization Code flow:
 
 ```typescript
-// 1. Redirect user to GroveAuth
+// 1. Redirect user to Heartwood
 const params = new URLSearchParams({
   client_id: 'your-client-id',
   redirect_uri: 'https://yoursite.com/auth/callback',
@@ -118,10 +122,10 @@ const params = new URLSearchParams({
   code_challenge: await generateCodeChallenge(verifier),
   code_challenge_method: 'S256'
 });
-redirect(`https://auth.grove.place/login?${params}`);
+redirect(`https://heartwood.grove.place/login?${params}`);
 
 // 2. Handle callback - exchange code for tokens
-const tokens = await fetch('https://auth.grove.place/token', {
+const tokens = await fetch('https://heartwood.grove.place/token', {
   method: 'POST',
   body: new URLSearchParams({
     grant_type: 'authorization_code',
@@ -134,7 +138,7 @@ const tokens = await fetch('https://auth.grove.place/token', {
 }).then(r => r.json());
 
 // 3. Verify tokens on protected routes
-const user = await fetch('https://auth.grove.place/verify', {
+const user = await fetch('https://heartwood.grove.place/verify', {
   headers: { Authorization: `Bearer ${tokens.access_token}` }
 }).then(r => r.json());
 ```
@@ -145,7 +149,7 @@ const user = await fetch('https://auth.grove.place/verify', {
 
 | Client ID | Site | Redirect URIs |
 |-----------|------|---------------|
-| `groveengine` | GroveEngine | `https://*.grove.place/auth/callback` |
+| `groveengine` | Lattice (GroveEngine) | `https://*.grove.place/auth/callback` |
 | `autumnsgrove` | AutumnsGrove | `https://autumnsgrove.place/auth/callback` |
 
 ---
@@ -223,4 +227,4 @@ MIT - AutumnsGrove
 
 ---
 
-*See [GROVEAUTH_SPEC.md](GROVEAUTH_SPEC.md) for complete technical specification*
+*See [GROVEAUTH_SPEC.md](GROVEAUTH_SPEC.md) for complete technical specification (internal codename used for file)*

--- a/docs/INTEGRATION_GUIDE.md
+++ b/docs/INTEGRATION_GUIDE.md
@@ -1,14 +1,17 @@
-# GroveAuth Integration Guide
+# Heartwood Integration Guide
 
-> How to add GroveAuth authentication to your site
+> How to add Heartwood authentication to your site
 
 ---
 
 ## Overview
 
-GroveAuth is a centralized authentication service for AutumnsGrove properties. Instead of implementing auth yourself, redirect users to GroveAuth and receive verified JWT tokens back.
+Heartwood is a centralized authentication service for AutumnsGrove properties. Instead of implementing auth yourself, redirect users to Heartwood and receive verified JWT tokens back.
 
-**Auth URL**: `https://auth.grove.place`
+**Public Name**: Heartwood
+**Internal Codename**: GroveAuth
+**Login UI**: `https://heartwood.grove.place`
+**API Base**: `https://auth-api.grove.place` (internal backend)
 
 ---
 
@@ -16,7 +19,7 @@ GroveAuth is a centralized authentication service for AutumnsGrove properties. I
 
 ### 1. Get Your Client Credentials
 
-Contact the GroveAuth admin to register your site. You'll receive:
+Contact the Heartwood admin to register your site. You'll receive:
 - `client_id` - Public identifier for your app
 - `client_secret` - Secret key (keep this secure, server-side only)
 
@@ -26,7 +29,7 @@ Your redirect URIs must be pre-registered (e.g., `https://yoursite.com/auth/call
 
 ### 2. Add Login Button
 
-Redirect users to GroveAuth with required parameters:
+Redirect users to Heartwood with required parameters:
 
 ```typescript
 // Generate PKCE values (required for security)
@@ -69,7 +72,7 @@ async function login() {
     code_challenge_method: 'S256'
   });
 
-  window.location.href = `https://auth.grove.place/login?${params}`;
+  window.location.href = `https://heartwood.grove.place/login?${params}`;
 }
 ```
 
@@ -77,7 +80,7 @@ async function login() {
 
 ### 3. Handle the Callback
 
-After authentication, GroveAuth redirects back with an authorization code:
+After authentication, Heartwood redirects back with an authorization code:
 
 ```
 https://yoursite.com/auth/callback?code=abc123&state=xyz789
@@ -107,8 +110,8 @@ async function handleAuthCallback(request: Request, env: Env) {
   // Get code verifier from session
   const codeVerifier = getCookie(request, 'code_verifier');
 
-  // Exchange code for tokens
-  const tokenResponse = await fetch('https://auth.grove.place/token', {
+  // Exchange code for tokens (via internal API)
+  const tokenResponse = await fetch('https://auth-api.grove.place/token', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -149,7 +152,7 @@ async function getAuthenticatedUser(request: Request): Promise<User | null> {
 
   const token = authHeader.substring(7);
 
-  const response = await fetch('https://auth.grove.place/verify', {
+  const response = await fetch('https://auth-api.grove.place/verify', {
     headers: {
       Authorization: `Bearer ${token}`,
     },
@@ -177,7 +180,7 @@ Access tokens expire after 1 hour. Use the refresh token to get new ones:
 
 ```typescript
 async function refreshAccessToken(refreshToken: string, env: Env) {
-  const response = await fetch('https://auth.grove.place/token/refresh', {
+  const response = await fetch('https://auth-api.grove.place/token/refresh', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -206,7 +209,7 @@ async function refreshAccessToken(refreshToken: string, env: Env) {
 
 ```typescript
 async function logout(accessToken: string) {
-  await fetch('https://auth.grove.place/logout', {
+  await fetch('https://auth-api.grove.place/logout', {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -284,7 +287,7 @@ For SvelteKit apps, here's a complete integration pattern:
 ```typescript
 import { env } from '$env/dynamic/private';
 
-const AUTH_BASE_URL = 'https://auth.grove.place';
+const AUTH_BASE_URL = 'https://auth-api.grove.place';  // Internal API endpoint
 
 export interface AuthTokens {
   access_token: string;
@@ -454,4 +457,4 @@ GROVEAUTH_REDIRECT_URI=https://yoursite.com/auth/callback
 
 ---
 
-*For questions or to register a new client, contact the GroveAuth admin.*
+*For questions or to register a new client, contact the Heartwood admin.*

--- a/docs/OAUTH_CLIENT_SETUP.md
+++ b/docs/OAUTH_CLIENT_SETUP.md
@@ -1,13 +1,16 @@
-# Setting Up a New OAuth Client for GroveAuth
+# Setting Up a New OAuth Client for Heartwood
 
-This guide walks through registering a new website/application as an OAuth client with GroveAuth.
+This guide walks through registering a new website/application as an OAuth client with Heartwood.
+
+**Public Name**: Heartwood
+**Internal Codename**: GroveAuth
 
 ## Important URLs
 
 | Service | URL | Purpose |
 |---------|-----|---------|
 | **API** (Worker) | `https://auth-api.grove.place` | Token exchange, verification, refresh |
-| **Frontend** (Pages) | `https://auth.grove.place` | Login UI, OAuth redirects |
+| **Frontend** (Pages) | `https://heartwood.grove.place` | Login UI, OAuth redirects |
 
 **Your client code should call `auth-api.grove.place`** for all API operations (token exchange, verify, refresh, logout).
 
@@ -55,7 +58,7 @@ echo "https://yoursite.com/auth/callback" | wrangler secret put GROVEAUTH_REDIRE
 
 ## Step 3: Generate the Secret Hash (Base64URL Format)
 
-**CRITICAL**: GroveAuth uses **base64url encoding** (with `-` and `_`, no padding), NOT standard base64 or hex!
+**CRITICAL**: Heartwood uses **base64url encoding** (with `-` and `_`, no padding), NOT standard base64 or hex!
 
 Generate the SHA-256 hash in the correct format:
 
@@ -80,9 +83,9 @@ echo "Hash for database: $CLIENT_SECRET_HASH"
 | base64 (wrong) | `Sdgtaokie8+H7GKw+tn0S/6XNSh1rdv/lP8wCfe7/6E=` | ❌ NO |
 | hex (wrong) | `49d82d6a89227bcf87ec62b0fad9f44b...` | ❌ NO |
 
-## Step 4: Register the Client in GroveAuth
+## Step 4: Register the Client in Heartwood
 
-Insert the client into the GroveAuth database:
+Insert the client into the Heartwood database:
 
 ```bash
 wrangler d1 execute groveauth --remote --command="
@@ -103,8 +106,8 @@ ON CONFLICT(client_id) DO UPDATE SET
 ```
 
 **Important fields:**
-- `redirect_uris`: Where GroveAuth can redirect after login (include localhost for dev)
-- `allowed_origins`: CORS origins that can make requests to GroveAuth
+- `redirect_uris`: Where Heartwood can redirect after login (include localhost for dev)
+- `allowed_origins`: CORS origins that can make requests to Heartwood
 - `client_secret_hash`: Must be **base64url encoded** (dashes, underscores, no padding)
 
 ## Step 5: Update wrangler.toml (Optional)
@@ -112,7 +115,7 @@ ON CONFLICT(client_id) DO UPDATE SET
 Add documentation comments to your site's `wrangler.toml`:
 
 ```toml
-# GroveAuth Secrets (configured via wrangler pages secret):
+# Heartwood Secrets (configured via wrangler pages secret):
 # - GROVEAUTH_CLIENT_ID (OAuth client ID)
 # - GROVEAUTH_CLIENT_SECRET (OAuth client secret - plaintext)
 # - GROVEAUTH_REDIRECT_URI (OAuth callback URL)
@@ -124,7 +127,7 @@ Add documentation comments to your site's `wrangler.toml`:
 
 2. Test the login flow:
    - Navigate to `https://yoursite.com/admin` (or protected route)
-   - Should redirect to `https://auth.grove.place/login`
+   - Should redirect to `https://heartwood.grove.place/login`
    - Choose Google, GitHub, or Magic Code authentication
    - After authentication, should redirect back to `/auth/callback`
    - Should create session and redirect to your app
@@ -135,7 +138,7 @@ For convenience, here's a complete script to generate everything:
 
 ```bash
 #!/bin/bash
-# Generate GroveAuth client credentials
+# Generate Heartwood client credentials
 
 CLIENT_ID="your-client-id"
 PROJECT_NAME="your-pages-project"
@@ -148,7 +151,7 @@ CLIENT_SECRET=$(openssl rand -base64 32)
 CLIENT_SECRET_HASH=$(echo -n "$CLIENT_SECRET" | openssl dgst -sha256 -binary | base64 | tr '+/' '-_' | tr -d '=')
 
 echo "=================================="
-echo "GroveAuth Client Credentials"
+echo "Heartwood Client Credentials"
 echo "=================================="
 echo ""
 echo "Client ID:     $CLIENT_ID"
@@ -165,7 +168,7 @@ echo "echo \"$CLIENT_ID\" | wrangler pages secret put GROVEAUTH_CLIENT_ID --proj
 echo "echo \"$CLIENT_SECRET\" | wrangler pages secret put GROVEAUTH_CLIENT_SECRET --project $PROJECT_NAME"
 echo "echo \"$SITE_URL/auth/callback\" | wrangler pages secret put GROVEAUTH_REDIRECT_URI --project $PROJECT_NAME"
 echo ""
-echo "# 2. Register in GroveAuth (update the SQL with your details):"
+echo "# 2. Register in Heartwood (update the SQL with your details):"
 echo "wrangler d1 execute groveauth --remote --command=\"INSERT INTO clients ...\""
 ```
 

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,6 +1,7 @@
 /**
- * GroveAuth Frontend Configuration
- * API URL points to the Cloudflare Worker backend
+ * Heartwood Frontend Configuration
+ * API URL points to the internal Cloudflare Worker backend (groveauth worker)
+ * Note: auth-api.grove.place is the internal API endpoint, not the public domain
  */
 
 export const AUTH_API_URL = 'https://auth-api.grove.place';

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -26,11 +26,11 @@
 
 <svelte:head>
   {#if isAdmin}
-    <title>Admin Dashboard - GroveAuth</title>
+    <title>Admin Dashboard - Heartwood</title>
   {:else}
-    <title>GroveAuth — Secure Authentication</title>
+    <title>Heartwood — Secure Authentication</title>
   {/if}
-  <meta name="description" content="Centralized authentication service for AutumnsGrove properties. Secure login with Google, GitHub, or email magic codes." />
+  <meta name="description" content="Heartwood is the centralized authentication service for AutumnsGrove properties. Secure login with Google, GitHub, or email magic codes." />
 </svelte:head>
 
 {#if isAdmin && needsLogin}
@@ -70,8 +70,8 @@
 
     <footer class="mt-16 text-center">
       <div class="flex items-center justify-center gap-4 text-sm font-sans text-bark/50 dark:text-gray-500">
-        <a href="https://auth.grove.place" class="hover:text-grove-600 dark:hover:text-grove-400 transition-colors">
-          GroveAuth Home
+        <a href="https://heartwood.grove.place" class="hover:text-grove-600 dark:hover:text-grove-400 transition-colors">
+          Heartwood Home
         </a>
       </div>
     </footer>
@@ -91,7 +91,7 @@
       <p class="text-bark/60 dark:text-gray-400 font-sans text-sm">{errorDescription}</p>
 
       <a
-        href="https://auth.grove.place"
+        href="https://heartwood.grove.place"
         class="inline-block mt-6 px-6 py-2 border border-grove-400 text-bark dark:text-gray-200 font-sans rounded-lg hover:bg-grove-50 dark:hover:bg-gray-700 transition-colors"
       >
         Back to Home
@@ -108,11 +108,11 @@
     </div>
 
     <!-- Title -->
-    <h1 class="text-4xl md:text-5xl font-serif text-bark dark:text-gray-100 mb-3 text-center">GroveAuth</h1>
+    <h1 class="text-4xl md:text-5xl font-serif text-bark dark:text-gray-100 mb-3 text-center">Heartwood</h1>
 
   <!-- Tagline -->
   <p class="text-xl md:text-2xl text-bark/70 dark:text-gray-400 font-serif italic mb-8 text-center">
-    Secure authentication for the Grove ecosystem
+    The authentic core of Grove authentication
   </p>
 
   <!-- Decorative divider -->
@@ -127,7 +127,7 @@
   <!-- Description -->
   <div class="max-w-xl text-center mb-12 space-y-4">
     <p class="text-bark/70 dark:text-gray-300 font-sans leading-relaxed">
-      GroveAuth provides secure, centralized authentication for all AutumnsGrove properties.
+      Heartwood provides secure, centralized authentication for all AutumnsGrove properties.
       Sign in once and access the entire ecosystem with a single identity.
     </p>
     <p class="text-bark/60 dark:text-gray-400 font-sans text-sm">

--- a/frontend/src/routes/dashboard/+page.svelte
+++ b/frontend/src/routes/dashboard/+page.svelte
@@ -35,7 +35,7 @@
 </script>
 
 <svelte:head>
-  <title>Admin Dashboard - GroveAuth</title>
+  <title>Admin Dashboard - Heartwood</title>
 </svelte:head>
 
 <main class="min-h-screen p-6 md:p-8">
@@ -45,7 +45,7 @@
       <Logo size="sm" />
       <div>
         <h1 class="text-2xl font-serif text-bark dark:text-gray-100">Admin Dashboard</h1>
-        <p class="text-sm text-bark/60 dark:text-gray-400 font-sans">GroveAuth Management</p>
+        <p class="text-sm text-bark/60 dark:text-gray-400 font-sans">Heartwood Management</p>
       </div>
     </div>
     <div class="flex items-center gap-4">

--- a/frontend/src/routes/error/+page.svelte
+++ b/frontend/src/routes/error/+page.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <svelte:head>
-  <title>Error — GroveAuth</title>
+  <title>Error — Heartwood</title>
 </svelte:head>
 
 <main class="min-h-screen flex flex-col items-center justify-center px-6 py-12">
@@ -43,6 +43,6 @@
   </div>
 
   <p class="mt-8 text-sm text-bark/50 font-sans">
-    Powered by <a href="https://grove.place" class="hover:text-grove-600 transition-colors">GroveAuth</a>
+    Powered by <a href="https://heartwood.grove.place" class="hover:text-grove-600 transition-colors">Heartwood</a>
   </p>
 </main>

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -116,14 +116,14 @@
 </script>
 
 <svelte:head>
-  <title>Sign In — GroveAuth</title>
-  <meta name="description" content="Sign in to your AutumnsGrove account" />
+  <title>Sign In — Heartwood</title>
+  <meta name="description" content="Sign in to your AutumnsGrove account via Heartwood" />
 </svelte:head>
 
 <main class="min-h-screen flex flex-col items-center justify-center px-6 py-12">
   <!-- Logo -->
   <div class="mb-8">
-    <a href="/" class="text-grove-600 hover:text-grove-700 transition-colors" aria-label="GroveAuth Home">
+    <a href="/" class="text-grove-600 hover:text-grove-700 transition-colors" aria-label="Heartwood Home">
       <Logo size="md" />
     </a>
   </div>
@@ -293,6 +293,6 @@
 
   <!-- Footer -->
   <p class="mt-8 text-sm text-bark/50 dark:text-gray-500 font-sans">
-    Powered by <a href="https://grove.place" class="hover:text-grove-600 dark:hover:text-grove-400 transition-colors">GroveAuth</a>
+    Powered by <a href="https://heartwood.grove.place" class="hover:text-grove-600 dark:hover:text-grove-400 transition-colors">Heartwood</a>
   </p>
 </main>

--- a/src/templates/login.ts
+++ b/src/templates/login.ts
@@ -1,6 +1,6 @@
 /**
- * Login Page Template
- * Styled to match GroveEngine aesthetic
+ * Heartwood Login Page Template
+ * Styled to match Grove ecosystem aesthetic
  */
 
 import type { LoginParams } from '../types.js';
@@ -35,7 +35,7 @@ export function getLoginPageHTML(options: LoginPageOptions): string {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Sign In - GroveAuth</title>
+  <title>Sign In - Heartwood</title>
   <style>
     :root {
       --color-bg: #fafaf9;
@@ -319,7 +319,7 @@ export function getLoginPageHTML(options: LoginPageOptions): string {
             <path d="M2 17l10 5 10-5"/>
             <path d="M2 12l10 5 10-5"/>
           </svg>
-          GroveAuth
+          Heartwood
         </h1>
       </div>
 
@@ -395,7 +395,7 @@ export function getLoginPageHTML(options: LoginPageOptions): string {
       ` : ''}
 
       <p class="footer">
-        Powered by <a href="https://grove.place" target="_blank">GroveAuth</a>
+        Powered by <a href="https://heartwood.grove.place" target="_blank">Heartwood</a>
       </p>
     </div>
   </div>

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,7 @@
-# GroveAuth - Centralized Authentication Service
-# Domain: auth.grove.place
+# Heartwood - Centralized Authentication Service
+# Public Name: Heartwood | Internal Codename: GroveAuth
+# Public Domain: heartwood.grove.place
+# API Domain: auth-api.grove.place (internal backend)
 
 name = "groveauth"
 main = "src/index.ts"


### PR DESCRIPTION
Rebrand user-facing text to use the new Grove naming system:
- Public name: Heartwood
- Internal codename: GroveAuth (preserved)
- Public domain: heartwood.grove.place
- API domain: auth-api.grove.place (internal, unchanged)

Updated files:
- README.md, AGENT.md, GROVEAUTH_SPEC.md headers
- Frontend UI text (titles, taglines, footers)
- Login template branding
- Integration documentation
- OAuth client setup guide

Preserved internal references:
- Worker name (groveauth)
- D1 database name (groveauth)
- Environment variables (GROVEAUTH_*)
- Internal code and variable names

Co-Authored-By: Claude <agent@localhost>