### PR TITLE
Update groveengine dependency to v0.6.1

### DIFF
--- a/src/db/migrations/003_update_tier_names.sql
+++ b/src/db/migrations/003_update_tier_names.sql
@@ -1,0 +1,37 @@
+-- Migration: Update subscription tier names to match GroveEngine v0.6.x
+-- Old: starter, professional, business
+-- New: seedling, sapling, evergreen, canopy, platform
+
+-- Update existing tier values
+UPDATE user_subscriptions SET tier = 'seedling' WHERE tier = 'starter';
+UPDATE user_subscriptions SET tier = 'sapling' WHERE tier = 'professional';
+UPDATE user_subscriptions SET tier = 'evergreen' WHERE tier = 'business';
+
+-- Note: SQLite does not support ALTER TABLE to modify CHECK constraints.
+-- The old constraint will remain but new inserts will only use new tier names.
+-- To fully update the schema, you would need to recreate the table.
+
+-- For production, consider running this recreate if needed:
+-- CREATE TABLE user_subscriptions_new (
+--   id TEXT PRIMARY KEY,
+--   user_id TEXT UNIQUE NOT NULL,
+--   tier TEXT NOT NULL DEFAULT 'seedling' CHECK (tier IN ('seedling', 'sapling', 'evergreen', 'canopy', 'platform')),
+--   post_limit INTEGER,
+--   post_count INTEGER NOT NULL DEFAULT 0,
+--   grace_period_start TEXT,
+--   grace_period_days INTEGER DEFAULT 14,
+--   stripe_customer_id TEXT,
+--   stripe_subscription_id TEXT,
+--   billing_period_start TEXT,
+--   billing_period_end TEXT,
+--   custom_domain TEXT,
+--   custom_domain_verified INTEGER DEFAULT 0,
+--   created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+--   updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+--   FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+-- );
+-- INSERT INTO user_subscriptions_new SELECT * FROM user_subscriptions;
+-- DROP TABLE user_subscriptions;
+-- ALTER TABLE user_subscriptions_new RENAME TO user_subscriptions;
+-- CREATE INDEX IF NOT EXISTS idx_user_subscriptions_user_id ON user_subscriptions(user_id);
+-- CREATE INDEX IF NOT EXISTS idx_user_subscriptions_tier ON user_subscriptions(tier);

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -498,7 +498,7 @@ export async function getUserSubscription(db: D1DatabaseOrSession, userId: strin
   return db.prepare('SELECT * FROM user_subscriptions WHERE user_id = ?').bind(userId).first<UserSubscription>();
 }
 
-export async function createUserSubscription(db: D1DatabaseOrSession, userId: string, tier: SubscriptionTier = 'starter'): Promise<UserSubscription> {
+export async function createUserSubscription(db: D1DatabaseOrSession, userId: string, tier: SubscriptionTier = 'seedling'): Promise<UserSubscription> {
   const id = generateUUID();
   const postLimit = TIER_POST_LIMITS[tier];
   const now = new Date().toISOString();
@@ -520,7 +520,7 @@ export async function createUserSubscription(db: D1DatabaseOrSession, userId: st
 export async function getOrCreateUserSubscription(db: D1DatabaseOrSession, userId: string): Promise<UserSubscription> {
   const existing = await getUserSubscription(db, userId);
   if (existing) return existing;
-  return createUserSubscription(db, userId, 'starter');
+  return createUserSubscription(db, userId, 'seedling');
 }
 
 export async function incrementPostCount(db: D1DatabaseOrSession, userId: string): Promise<UserSubscription | null> {
@@ -605,7 +605,7 @@ export async function updateSubscriptionTier(db: D1DatabaseOrSession, userId: st
   ).bind(newTier, newPostLimit, graceStart, now, userId).run();
 
   // Determine event type
-  const tierOrder = { starter: 0, professional: 1, business: 2 };
+  const tierOrder: Record<SubscriptionTier, number> = { seedling: 0, sapling: 1, evergreen: 2, canopy: 3, platform: 4 };
   const eventType: SubscriptionAuditEventType = tierOrder[newTier] > tierOrder[oldTier] ? 'tier_upgraded' : 'tier_downgraded';
 
   await createSubscriptionAuditLog(db, {

--- a/src/routes/subscription.ts
+++ b/src/routes/subscription.ts
@@ -140,7 +140,7 @@ subscription.post('/:userId/post-count', async (c) => {
 
 /**
  * PUT /subscription/:userId/tier - Update subscription tier
- * Body: { tier: 'starter' | 'professional' | 'business' }
+ * Body: { tier: 'seedling' | 'sapling' | 'evergreen' | 'canopy' | 'platform' }
  */
 subscription.put('/:userId/tier', async (c) => {
   const payload = await verifyBearerToken(c);
@@ -158,11 +158,11 @@ subscription.put('/:userId/tier', async (c) => {
     return c.json({ error: 'invalid_request', error_description: 'Invalid JSON body' }, 400);
   }
 
-  const validTiers: SubscriptionTier[] = ['starter', 'professional', 'business'];
+  const validTiers: SubscriptionTier[] = ['seedling', 'sapling', 'evergreen', 'canopy', 'platform'];
   if (!body.tier || !validTiers.includes(body.tier as SubscriptionTier)) {
     return c.json({
       error: 'invalid_request',
-      error_description: 'Body must contain { tier: "starter" | "professional" | "business" }'
+      error_description: 'Body must contain { tier: "seedling" | "sapling" | "evergreen" | "canopy" | "platform" }'
     }, 400);
   }
 

--- a/src/templates/login.ts
+++ b/src/templates/login.ts
@@ -36,6 +36,9 @@ export function getLoginPageHTML(options: LoginPageOptions): string {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sign In - Heartwood</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@400;500;600;700&display=swap" rel="stylesheet">
   <style>
     :root {
       --color-bg: #fafaf9;
@@ -75,7 +78,7 @@ export function getLoginPageHTML(options: LoginPageOptions): string {
     }
 
     body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      font-family: 'Lexend', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--color-bg);
       color: var(--color-text);
       min-height: 100vh;

--- a/src/types.ts
+++ b/src/types.ts
@@ -255,7 +255,7 @@ export interface AuthError {
 // SUBSCRIPTION TYPES
 // =============================================================================
 
-export type SubscriptionTier = 'starter' | 'professional' | 'business';
+export type SubscriptionTier = 'seedling' | 'sapling' | 'evergreen' | 'canopy' | 'platform';
 
 export interface UserSubscription {
   id: string;
@@ -297,9 +297,11 @@ export type SubscriptionAuditEventType =
   | 'custom_domain_removed';
 
 export const TIER_POST_LIMITS: Record<SubscriptionTier, number | null> = {
-  starter: 250,
-  professional: 2000,
-  business: null,
+  seedling: 250,
+  sapling: 2000,
+  evergreen: 10000,
+  canopy: null,
+  platform: null,
 };
 
 export interface SubscriptionStatus {


### PR DESCRIPTION
- Rename subscription tiers: starter→seedling, professional→sapling, business→evergreen, add canopy and platform tiers
- Update TIER_POST_LIMITS with new tier names and limits
- Add Lexend font to login template (Grove ecosystem default)
- Add database migration for tier name updates