### PR TITLE
feat: add wildcard tenant-aware redirect URI validation

### DIFF
--- a/src/db/queries.test.ts
+++ b/src/db/queries.test.ts
@@ -1,0 +1,374 @@
+/**
+ * Tests for wildcard redirect URI validation
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  extractSubdomainFromRedirectUri,
+  isActiveTenant,
+  validateClientRedirectUri,
+} from './queries.js';
+
+// Mock D1Database
+const createMockDb = (clientData: Record<string, unknown> | null = null) => ({
+  prepare: vi.fn().mockReturnValue({
+    bind: vi.fn().mockReturnValue({
+      first: vi.fn().mockResolvedValue(clientData),
+      all: vi.fn().mockResolvedValue({ results: [] }),
+      run: vi.fn().mockResolvedValue({ success: true }),
+    }),
+  }),
+});
+
+describe('extractSubdomainFromRedirectUri', () => {
+  describe('groveengine client', () => {
+    it('extracts subdomain from valid redirect URI', () => {
+      const subdomain = extractSubdomainFromRedirectUri(
+        'groveengine',
+        'https://autumn.grove.place/auth/callback'
+      );
+      expect(subdomain).toBe('autumn');
+    });
+
+    it('normalizes subdomain to lowercase', () => {
+      const subdomain = extractSubdomainFromRedirectUri(
+        'groveengine',
+        'https://AUTUMN.grove.place/auth/callback'
+      );
+      expect(subdomain).toBe('autumn');
+    });
+
+    it('handles hyphenated subdomains', () => {
+      const subdomain = extractSubdomainFromRedirectUri(
+        'groveengine',
+        'https://my-cool-blog.grove.place/auth/callback'
+      );
+      expect(subdomain).toBe('my-cool-blog');
+    });
+
+    it('handles numeric subdomains', () => {
+      const subdomain = extractSubdomainFromRedirectUri(
+        'groveengine',
+        'https://user123.grove.place/auth/callback'
+      );
+      expect(subdomain).toBe('user123');
+    });
+
+    it('returns null for wrong path', () => {
+      const subdomain = extractSubdomainFromRedirectUri(
+        'groveengine',
+        'https://autumn.grove.place/wrong/path'
+      );
+      expect(subdomain).toBeNull();
+    });
+
+    it('returns null for wrong domain', () => {
+      const subdomain = extractSubdomainFromRedirectUri(
+        'groveengine',
+        'https://autumn.evil.com/auth/callback'
+      );
+      expect(subdomain).toBeNull();
+    });
+
+    it('returns null for nested subdomains (security)', () => {
+      // This is critical for security - nested subdomains could be attack vectors
+      const subdomain = extractSubdomainFromRedirectUri(
+        'groveengine',
+        'https://evil.attacker.grove.place/auth/callback'
+      );
+      expect(subdomain).toBeNull();
+    });
+
+    it('returns null for HTTP (non-HTTPS)', () => {
+      const subdomain = extractSubdomainFromRedirectUri(
+        'groveengine',
+        'http://autumn.grove.place/auth/callback'
+      );
+      expect(subdomain).toBeNull();
+    });
+
+    it('returns null for root domain', () => {
+      const subdomain = extractSubdomainFromRedirectUri(
+        'groveengine',
+        'https://grove.place/auth/callback'
+      );
+      expect(subdomain).toBeNull();
+    });
+
+    it('returns null for www subdomain edge case', () => {
+      const subdomain = extractSubdomainFromRedirectUri(
+        'groveengine',
+        'https://www.grove.place/auth/callback'
+      );
+      // www is valid alphanumeric, so it matches the pattern
+      // This is expected - www would need to be an active tenant to pass full validation
+      expect(subdomain).toBe('www');
+    });
+  });
+
+  describe('unknown clients', () => {
+    it('returns null for unknown client_id', () => {
+      const subdomain = extractSubdomainFromRedirectUri(
+        'unknown-client',
+        'https://autumn.grove.place/auth/callback'
+      );
+      expect(subdomain).toBeNull();
+    });
+
+    it('returns null for third-party clients', () => {
+      const subdomain = extractSubdomainFromRedirectUri(
+        'some-third-party-app',
+        'https://app.example.com/callback'
+      );
+      expect(subdomain).toBeNull();
+    });
+  });
+});
+
+describe('isActiveTenant', () => {
+  it('returns true for active tenant', async () => {
+    const mockDb = createMockDb({ 1: 1 });
+    const result = await isActiveTenant(mockDb as unknown as D1Database, 'autumn');
+
+    expect(result).toBe(true);
+    expect(mockDb.prepare).toHaveBeenCalledWith(
+      'SELECT 1 FROM tenants WHERE subdomain = ? AND active = 1'
+    );
+  });
+
+  it('returns false for non-existent tenant', async () => {
+    const mockDb = createMockDb(null);
+    const result = await isActiveTenant(mockDb as unknown as D1Database, 'doesnotexist');
+
+    expect(result).toBe(false);
+  });
+
+  it('normalizes subdomain to lowercase', async () => {
+    const mockDb = createMockDb({ 1: 1 });
+    await isActiveTenant(mockDb as unknown as D1Database, 'AUTUMN');
+
+    const bindCall = mockDb.prepare().bind;
+    expect(bindCall).toHaveBeenCalledWith('autumn');
+  });
+});
+
+describe('validateClientRedirectUri', () => {
+  const createMockClient = (redirectUris: string[]) => ({
+    id: 'test-id',
+    name: 'Test Client',
+    client_id: 'groveengine',
+    client_secret_hash: 'hash',
+    redirect_uris: JSON.stringify(redirectUris),
+    allowed_origins: '[]',
+    domain: null,
+    is_internal_service: 0,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+  });
+
+  describe('exact match (backward compatibility)', () => {
+    it('allows exact match from registered redirect_uris', async () => {
+      const client = createMockClient([
+        'https://grove.place/auth/callback',
+        'https://admin.grove.place/auth/callback',
+      ]);
+      const mockDb = createMockDb(client);
+
+      const result = await validateClientRedirectUri(
+        mockDb as unknown as D1Database,
+        'groveengine',
+        'https://grove.place/auth/callback'
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('rejects non-matching URI without engineDb', async () => {
+      const client = createMockClient(['https://grove.place/auth/callback']);
+      const mockDb = createMockDb(client);
+
+      const result = await validateClientRedirectUri(
+        mockDb as unknown as D1Database,
+        'groveengine',
+        'https://autumn.grove.place/auth/callback'
+        // No engineDb provided - wildcard validation skipped
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('wildcard validation with engineDb', () => {
+    it('allows wildcard URI for active tenant', async () => {
+      const client = createMockClient(['https://grove.place/auth/callback']);
+      const mockHeartwood = createMockDb(client);
+
+      // Mock ENGINE_DB that returns an active tenant
+      const mockEngineDb = createMockDb({ 1: 1 });
+
+      const result = await validateClientRedirectUri(
+        mockHeartwood as unknown as D1Database,
+        'groveengine',
+        'https://autumn.grove.place/auth/callback',
+        mockEngineDb as unknown as D1Database
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it('rejects wildcard URI for non-existent tenant', async () => {
+      const client = createMockClient(['https://grove.place/auth/callback']);
+      const mockHeartwood = createMockDb(client);
+
+      // Mock ENGINE_DB that returns no tenant
+      const mockEngineDb = createMockDb(null);
+
+      const result = await validateClientRedirectUri(
+        mockHeartwood as unknown as D1Database,
+        'groveengine',
+        'https://doesnotexist.grove.place/auth/callback',
+        mockEngineDb as unknown as D1Database
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('rejects wildcard URI for suspended tenant (active = 0)', async () => {
+      const client = createMockClient(['https://grove.place/auth/callback']);
+      const mockHeartwood = createMockDb(client);
+
+      // Mock ENGINE_DB - the query has WHERE active = 1, so suspended tenants return null
+      const mockEngineDb = createMockDb(null);
+
+      const result = await validateClientRedirectUri(
+        mockHeartwood as unknown as D1Database,
+        'groveengine',
+        'https://suspended-user.grove.place/auth/callback',
+        mockEngineDb as unknown as D1Database
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('prioritizes exact match over wildcard', async () => {
+      // If URI is in redirect_uris, we don't even check engineDb
+      const client = createMockClient([
+        'https://grove.place/auth/callback',
+        'https://autumn.grove.place/auth/callback', // Explicit entry
+      ]);
+      const mockHeartwood = createMockDb(client);
+
+      // ENGINE_DB should NOT be called because exact match succeeds first
+      const mockEngineDb = createMockDb(null);
+
+      const result = await validateClientRedirectUri(
+        mockHeartwood as unknown as D1Database,
+        'groveengine',
+        'https://autumn.grove.place/auth/callback',
+        mockEngineDb as unknown as D1Database
+      );
+
+      expect(result).toBe(true);
+      // Verify engineDb was NOT queried (exact match short-circuited)
+      expect(mockEngineDb.prepare).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('non-groveengine clients', () => {
+    it('only uses exact match for non-wildcard clients', async () => {
+      const client = {
+        ...createMockClient(['https://example.com/callback']),
+        client_id: 'third-party-app',
+      };
+      const mockHeartwood = createMockDb(client);
+      const mockEngineDb = createMockDb({ 1: 1 }); // Would return active tenant
+
+      const result = await validateClientRedirectUri(
+        mockHeartwood as unknown as D1Database,
+        'third-party-app',
+        'https://autumn.grove.place/auth/callback', // Not in their redirect_uris
+        mockEngineDb as unknown as D1Database
+      );
+
+      expect(result).toBe(false);
+      // engineDb shouldn't be queried for non-groveengine clients
+      expect(mockEngineDb.prepare).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('client not found', () => {
+    it('returns false when client does not exist', async () => {
+      const mockDb = createMockDb(null); // No client found
+
+      const result = await validateClientRedirectUri(
+        mockDb as unknown as D1Database,
+        'nonexistent-client',
+        'https://example.com/callback'
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('security edge cases', () => {
+    it('rejects nested subdomains', async () => {
+      const client = createMockClient(['https://grove.place/auth/callback']);
+      const mockHeartwood = createMockDb(client);
+      const mockEngineDb = createMockDb({ 1: 1 }); // Would return active
+
+      const result = await validateClientRedirectUri(
+        mockHeartwood as unknown as D1Database,
+        'groveengine',
+        'https://evil.attacker.grove.place/auth/callback',
+        mockEngineDb as unknown as D1Database
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('rejects HTTP scheme', async () => {
+      const client = createMockClient(['https://grove.place/auth/callback']);
+      const mockHeartwood = createMockDb(client);
+      const mockEngineDb = createMockDb({ 1: 1 });
+
+      const result = await validateClientRedirectUri(
+        mockHeartwood as unknown as D1Database,
+        'groveengine',
+        'http://autumn.grove.place/auth/callback',
+        mockEngineDb as unknown as D1Database
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('rejects wrong path', async () => {
+      const client = createMockClient(['https://grove.place/auth/callback']);
+      const mockHeartwood = createMockDb(client);
+      const mockEngineDb = createMockDb({ 1: 1 });
+
+      const result = await validateClientRedirectUri(
+        mockHeartwood as unknown as D1Database,
+        'groveengine',
+        'https://autumn.grove.place/wrong/callback',
+        mockEngineDb as unknown as D1Database
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('rejects path traversal attempts', async () => {
+      const client = createMockClient(['https://grove.place/auth/callback']);
+      const mockHeartwood = createMockDb(client);
+      const mockEngineDb = createMockDb({ 1: 1 });
+
+      const result = await validateClientRedirectUri(
+        mockHeartwood as unknown as D1Database,
+        'groveengine',
+        'https://autumn.grove.place/auth/callback/../../../etc/passwd',
+        mockEngineDb as unknown as D1Database
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/routes/login.ts
+++ b/src/routes/login.ts
@@ -53,10 +53,12 @@ login.get('/', async (c) => {
   }
 
   // Validate redirect_uri is registered for this client
+  // Pass ENGINE_DB for wildcard tenant validation (*.grove.place subdomains)
   const validRedirect = await validateClientRedirectUri(
     db,
     validParams.client_id,
-    validParams.redirect_uri
+    validParams.redirect_uri,
+    c.env.ENGINE_DB
   );
   if (!validRedirect) {
     return c.html(

--- a/src/routes/magic.ts
+++ b/src/routes/magic.ts
@@ -94,7 +94,8 @@ magic.post('/send', async (c) => {
   }
 
   // Validate redirect URI
-  const validRedirect = await validateClientRedirectUri(db, client_id, redirect_uri);
+  // Pass ENGINE_DB for wildcard tenant validation (*.grove.place subdomains)
+  const validRedirect = await validateClientRedirectUri(db, client_id, redirect_uri, c.env.ENGINE_DB);
   if (!validRedirect) {
     return c.json({ error: 'invalid_request', message: 'Invalid redirect_uri' }, 400);
   }
@@ -170,7 +171,8 @@ magic.post('/verify', async (c) => {
   }
 
   // Validate redirect URI
-  const validRedirect = await validateClientRedirectUri(db, client_id, redirect_uri);
+  // Pass ENGINE_DB for wildcard tenant validation (*.grove.place subdomains)
+  const validRedirect = await validateClientRedirectUri(db, client_id, redirect_uri, c.env.ENGINE_DB);
   if (!validRedirect) {
     return c.json({ error: 'invalid_request', message: 'Invalid redirect_uri' }, 400);
   }

--- a/src/routes/oauth/google.ts
+++ b/src/routes/oauth/google.ts
@@ -60,10 +60,12 @@ google.get('/', async (c) => {
   }
 
   // Validate redirect URI
+  // Pass ENGINE_DB for wildcard tenant validation (*.grove.place subdomains)
   const validRedirect = await validateClientRedirectUri(
     db,
     validParams.client_id,
-    validParams.redirect_uri
+    validParams.redirect_uri,
+    c.env.ENGINE_DB
   );
   if (!validRedirect) {
     return c.json({ error: 'invalid_request', error_description: 'Invalid redirect_uri' }, 400);


### PR DESCRIPTION
## Summary

- Enables dynamic validation of `*.grove.place` redirect URIs by verifying the subdomain exists as an active tenant in GroveEngine's D1 database
- Eliminates the need to manually register each tenant subdomain in the `groveengine` client's `redirect_uris` array
- **V1 blocker** — critical for multi-tenant launch where new tenants can sign up at any time

## Changes

| File | Changes |
|------|---------|
| `src/db/queries.ts` | Added `WILDCARD_CLIENTS` config, `extractSubdomainFromRedirectUri()`, `isActiveTenant()`, modified `validateClientRedirectUri()` |
| `src/routes/login.ts` | Pass `c.env.ENGINE_DB` to validation |
| `src/routes/oauth/google.ts` | Pass `c.env.ENGINE_DB` to validation |
| `src/routes/magic.ts` | Pass `c.env.ENGINE_DB` to validation (2 locations) |
| `src/db/queries.test.ts` | **New** — 27 comprehensive tests |

## Validation Flow

```
validateClientRedirectUri(db, clientId, redirectUri, engineDb?)
                              │
                              ▼
                    ┌─────────────────┐
                    │ Check exact     │───── YES ───▶ ✅ ALLOW
                    │ match in array? │
                    └────────┬────────┘
                             │ NO
                             ▼
                    ┌─────────────────┐
                    │ Is groveengine  │───── NO ────▶ ❌ DENY
                    │ client?         │
                    └────────┬────────┘
                             │ YES
                             ▼
                    ┌─────────────────┐
                    │ Match pattern:  │───── NO ────▶ ❌ DENY
                    │ *.grove.place   │
                    │ /auth/callback? │
                    └────────┬────────┘
                             │ YES (extract subdomain)
                             ▼
                    ┌─────────────────┐
                    │ Query ENGINE_DB:│
                    │ SELECT 1 FROM   │
                    │ tenants WHERE   │
                    │ subdomain = ?   │
                    │ AND active = 1  │
                    └────────┬────────┘
                             │
                    ┌────────┴────────┐
                    │                 │
               FOUND ▼            NOT FOUND ▼
              ✅ ALLOW              ❌ DENY
```

## Security Considerations

| Risk | Mitigation |
|------|-----------|
| Nested subdomain attacks | Regex `[a-z0-9-]+` prevents dots (no `evil.attacker.grove.place`) |
| Suspended tenant hijacking | Query filters `WHERE active = 1` |
| Case sensitivity issues | Subdomain normalized to lowercase |
| Backward compatibility | Exact match checked first, wildcard is additive |

## Test plan

- [x] All 27 unit tests pass (`pnpm test:run`)
- [ ] Test login flow for existing tenant (`autumn.grove.place`)
- [ ] Test that non-existent subdomains are rejected
- [ ] Deploy to staging and verify with real OAuth flow

🤖 Generated with [Claude Code](https://claude.ai/code)