### PR TITLE
fix(security): S1 Auth & Sessions hardening

### DIFF
--- a/src/routes/device.ts
+++ b/src/routes/device.ts
@@ -291,8 +291,11 @@ device.post('/device/authorize', async (c) => {
     // Origin header missing — check Referer as fallback
     const referer = c.req.header('Referer');
     if (referer) {
+      // Extract origin from Referer URL for exact comparison.
+      // startsWith would allow "https://auth.grove.place.evil.com" to bypass.
       const authOrigin = new URL(c.env.AUTH_BASE_URL).origin;
-      if (!referer.startsWith(authOrigin)) {
+      const refererOrigin = new URL(referer).origin;
+      if (refererOrigin !== authOrigin) {
         return c.json(
           { error: 'invalid_request', error_description: 'Invalid origin' },
           403

--- a/src/routes/session.ts
+++ b/src/routes/session.ts
@@ -636,9 +636,11 @@ session.post("/validate-service", async (c) => {
   // In production, this endpoint should only be called via Cloudflare Service Bindings
   // (which bypass the public internet). The SERVICE_SECRET check provides defense-in-depth
   // for cases where the endpoint is accessible on the public HTTP routes.
+  // Always extract the header to avoid timing differences that could reveal
+  // whether SERVICE_SECRET is configured.
+  const serviceAuthHeader = c.req.header("Authorization");
   if (c.env.SERVICE_SECRET) {
-    const authHeader = c.req.header("Authorization");
-    if (!authHeader || authHeader !== `Bearer ${c.env.SERVICE_SECRET}`) {
+    if (!serviceAuthHeader || serviceAuthHeader !== `Bearer ${c.env.SERVICE_SECRET}`) {
       return c.json({ valid: false, error: "Unauthorized" }, 401);
     }
   }

--- a/src/routes/session.ts
+++ b/src/routes/session.ts
@@ -19,7 +19,7 @@ import {
   getUserClientPreference,
   isEmailAdmin,
 } from "../db/queries.js";
-import { hashSecret } from "../utils/crypto.js";
+import { hashSecret, timingSafeEqual } from "../utils/crypto.js";
 import { verifyAccessToken } from "../services/jwt.js";
 import { createDbSession } from "../db/session.js";
 import {
@@ -640,7 +640,7 @@ session.post("/validate-service", async (c) => {
   // whether SERVICE_SECRET is configured.
   const serviceAuthHeader = c.req.header("Authorization");
   if (c.env.SERVICE_SECRET) {
-    if (!serviceAuthHeader || serviceAuthHeader !== `Bearer ${c.env.SERVICE_SECRET}`) {
+    if (!serviceAuthHeader || !timingSafeEqual(serviceAuthHeader, `Bearer ${c.env.SERVICE_SECRET}`)) {
       return c.json({ valid: false, error: "Unauthorized" }, 401);
     }
   }

--- a/src/routes/verify.test.ts
+++ b/src/routes/verify.test.ts
@@ -212,7 +212,7 @@ describe('GET /userinfo', () => {
       expect(json.error).toBe('invalid_token');
     });
 
-    it('returns 401 if user not found', async () => {
+    it('returns same error as invalid token when user not found (prevents enumeration)', async () => {
       (verifyAccessToken as ReturnType<typeof vi.fn>).mockResolvedValue({
         sub: 'nonexistent-user',
         client_id: 'test-app',
@@ -223,7 +223,8 @@ describe('GET /userinfo', () => {
       expect(res.status).toBe(401);
       const json = await res.json() as ErrorResponse;
       expect(json.error).toBe('invalid_token');
-      expect(json.error_description).toContain('User not found');
+      // SECURITY: Must NOT reveal that the user was deleted/not found
+      expect(json.error_description).toBe('Token is invalid or expired');
     });
   });
 

--- a/src/routes/verify.ts
+++ b/src/routes/verify.ts
@@ -68,7 +68,9 @@ verify.get('/userinfo', async (c) => {
   const user = await getUserById(db, payload.sub);
 
   if (!user) {
-    return c.json({ error: 'invalid_token', error_description: 'User not found' }, 401);
+    // SECURITY: Return same error as invalid token to prevent user enumeration
+    // (attacker with token for deleted user shouldn't learn user was deleted)
+    return c.json({ error: 'invalid_token', error_description: 'Token is invalid or expired' }, 401);
   }
 
   const response: UserInfo = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,9 @@ export interface Env {
   // Passkey configuration (optional - defaults to 'grove.place')
   PASSKEY_RP_ID?: string;
 
+  // Service-to-service authentication (optional — defense-in-depth for validate-service)
+  SERVICE_SECRET?: string;
+
   // Secrets (set via wrangler secret put)
   JWT_PRIVATE_KEY: string;
   JWT_PUBLIC_KEY: string;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -26,6 +26,10 @@ export const RATE_LIMIT_SESSION_SERVICE = 100; // per minute for internal servic
 // Admin rate limiting
 export const RATE_LIMIT_ADMIN_PER_IP = 30; // per minute
 
+// Magic link rate limiting (prevents email flooding via Better Auth endpoint)
+export const RATE_LIMIT_MAGIC_LINK = 5; // per 15 minutes per IP
+export const RATE_LIMIT_MAGIC_LINK_WINDOW = 900; // 15 minutes in seconds
+
 // Passkey rate limiting (defense-in-depth alongside Better Auth's internal limits)
 export const RATE_LIMIT_PASSKEY_REGISTER = 5; // per hour per user
 export const RATE_LIMIT_PASSKEY_DELETE = 10; // per hour per user
@@ -56,6 +60,7 @@ export const SECURITY_HEADERS = {
   'X-Content-Type-Options': 'nosniff',
   'X-Frame-Options': 'DENY',
   'Referrer-Policy': 'strict-origin-when-cross-origin',
+  'Permissions-Policy': 'geolocation=(), microphone=(), camera=()',
   'Content-Security-Policy':
     "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; font-src 'self'",
 };

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -106,16 +106,19 @@ export async function verifySecret(secret: string, hash: string): Promise<boolea
 }
 
 /**
- * Timing-safe string comparison to prevent timing attacks
+ * Timing-safe string comparison to prevent timing attacks.
+ *
+ * SECURITY: Avoids early returns that could leak length information.
+ * Uses Math.max to iterate the full length of the longer string,
+ * and accumulates the length difference into the result variable.
+ * This ensures comparison time is proportional to the longer input,
+ * not the shorter one (which would reveal partial length info).
  */
 export function timingSafeEqual(a: string, b: string): boolean {
-  if (a.length !== b.length) {
-    return false;
-  }
-
-  let result = 0;
-  for (let i = 0; i < a.length; i++) {
-    result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  const maxLength = Math.max(a.length, b.length);
+  let result = a.length ^ b.length; // Accumulate length difference
+  for (let i = 0; i < maxLength; i++) {
+    result |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
   }
   return result === 0;
 }

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -115,10 +115,16 @@ export async function verifySecret(secret: string, hash: string): Promise<boolea
  * not the shorter one (which would reveal partial length info).
  */
 export function timingSafeEqual(a: string, b: string): boolean {
-  const maxLength = Math.max(a.length, b.length);
-  let result = a.length ^ b.length; // Accumulate length difference
+  const aLen = a.length;
+  const bLen = b.length;
+  const maxLength = Math.max(aLen, bLen);
+  let result = aLen ^ bLen; // Accumulate length difference
   for (let i = 0; i < maxLength; i++) {
-    result |= (a.charCodeAt(i) || 0) ^ (b.charCodeAt(i) || 0);
+    // Explicit bounds check avoids NaN-to-0 coercion via || operator,
+    // which could introduce subtle branch timing differences
+    const aCode = i < aLen ? a.charCodeAt(i) : 0;
+    const bCode = i < bLen ? b.charCodeAt(i) : 0;
+    result |= aCode ^ bCode;
   }
   return result === 0;
 }


### PR DESCRIPTION
## Summary

Section 1 of the Turtle Security Hardening Plan — Auth & Sessions audit and fixes for GroveAuth (Heartwood).

**Fixes:**
- `timingSafeEqual` in crypto.ts: fix length info leak via early return (now uses `Math.max` pattern)
- `/userinfo`: prevent user enumeration — uniform "Token is invalid or expired" error
- `validate-service`: add optional `SERVICE_SECRET` bearer token check (defense-in-depth)
- Magic link sign-in: add rate limiting (5 req/15 min per IP) via new `magicLinkRateLimiter`
- Token rate limiter: fall back to IP-based rate limiting when `client_id` not in query params
- `betterAuth.ts` 500 errors: strip `debug` field from JSON responses
- Device auth POST: add Origin/Referer CSRF validation
- `SECURITY_HEADERS`: add missing `Permissions-Policy` header
- Updated verify test to match enumeration prevention fix

**Companion PR:** GroveEngine `security/s1-auth-sessions-hardening` (getCookie regex, service binding, POST logout, hardening report)

## Test plan

- [x] 318 tests pass, 20 pre-existing failures (login rendering + rate limit mock setup)
- [x] Verify test updated: now asserts uniform error message for missing user
- [ ] Manual: confirm magic link rate limiting triggers after 5 requests
- [ ] Manual: confirm device authorization page still works with Origin validation
- [ ] Deploy `SERVICE_SECRET` via `wrangler secret put` before using validate-service auth


🤖 Generated with [Claude Code](https://claude.com/claude-code)